### PR TITLE
hw: SBC uses a different endpoint address for output

### DIFF
--- a/hw/xbox/xid.c
+++ b/hw/xbox/xid.c
@@ -546,7 +546,9 @@ static void usb_xid_handle_data(USBDevice *dev, USBPacket *p)
         }
         break;
     case USB_TOKEN_OUT:
-        if (p->ep->nr == 2) {
+        if (p->ep->nr == 1) {
+            // TODO: Update output for Steel Battalion Controller here
+        } else if (p->ep->nr == 2) {
             if(p->iov.size < 20) {
                 USBXIDGamepadState *s = DO_UPCAST(USBXIDGamepadState, dev, dev);
                 usb_packet_copy(p, &s->out_state, s->out_state.length);

--- a/hw/xbox/xid.c
+++ b/hw/xbox/xid.c
@@ -530,7 +530,7 @@ static void usb_xid_handle_data(USBDevice *dev, USBPacket *p)
     DPRINTF("xid handle_data 0x%x %d 0x%zx\n", p->pid, p->ep->nr, p->iov.size);
 
     assert(dev->usb_desc);
-    uint16_t vendor = dev->usb_desc->id->idVendor;
+    uint16_t vendor = dev->usb_desc->id.idVendor;
 
     switch (p->pid) {
     case USB_TOKEN_IN:

--- a/hw/xbox/xid.c
+++ b/hw/xbox/xid.c
@@ -529,20 +529,17 @@ static void usb_xid_handle_data(USBDevice *dev, USBPacket *p)
 {
     DPRINTF("xid handle_data 0x%x %d 0x%zx\n", p->pid, p->ep->nr, p->iov.size);
 
-    assert(dev->usb_desc);
-    uint16_t vendor = dev->usb_desc->id.idVendor;
+    const USBDesc * desc = usb_device_get_usb_desc(dev);
+    assert(desc);
 
     switch (p->pid) {
     case USB_TOKEN_IN:
         if (p->ep->nr == 2) {
-            if (vendor == USB_VENDOR_CAPCOM)
-            {
+            if (desc->id.idVendor == USB_VENDOR_CAPCOM) {
                 USBXIDSteelBattalionState *s = DO_UPCAST(USBXIDSteelBattalionState, dev, dev);
                 update_sb_input(s);
                 usb_packet_copy(p, &s->in_state, s->in_state.bLength);
-            }
-            else if (vendor == USB_VENDOR_MICROSOFT)
-            {
+            } else if (desc->id.idVendor == USB_VENDOR_MICROSOFT) {
                 USBXIDGamepadState *s = DO_UPCAST(USBXIDGamepadState, dev, dev);
                 update_input(s);
                 usb_packet_copy(p, &s->in_state, s->in_state.bLength);
@@ -557,7 +554,7 @@ static void usb_xid_handle_data(USBDevice *dev, USBPacket *p)
         if (p->ep->nr == 1) {
             // TODO: Update output for Steel Battalion Controller here
         } else if (p->ep->nr == 2) {
-            if (vendor == USB_VENDOR_MICROSOFT) {
+            if (desc->id.idVendor == USB_VENDOR_MICROSOFT) {
                 USBXIDGamepadState *s = DO_UPCAST(USBXIDGamepadState, dev, dev);
                 usb_packet_copy(p, &s->out_state, s->out_state.length);
                 update_output(s);


### PR DESCRIPTION
Hey so I am also interested in implementing SBC support for XEMU, but it looks like you're further along than I am in that regard.

I was trying out your build and encountered a crash as a result of not handling data output from the xbox to the SBC correctly. The SBC uses USB endpoint address 0x01 instead of 0x02 like most xbox controllers for outputting data. I also threw in a better way to differentiate which controller the Xbox is talking to using USB vendor IDs.

Here's a quick PR to fix that issue.